### PR TITLE
Feature/Display group members in group menu

### DIFF
--- a/src/groups/templates/groups/group_menu.html
+++ b/src/groups/templates/groups/group_menu.html
@@ -17,6 +17,12 @@
         <!-- グループがプライベートで招待コードがある場合の表示 -->
         <p><strong>Invite Code:</strong> {{ group.invite_code }}</p>
     {% endif %}
+    <h2>Group Members</h2>
+    <ul>
+      {% for member in members %}
+        <li>{{ member.user.username }}</li>
+      {% endfor %}
+    </ul>
     <!-- グループの設定リンク -->
     <a href="{% url 'group_management' %}">グループの設定</a>
     <!-- グループ離脱フォーム -->

--- a/src/groups/views.py
+++ b/src/groups/views.py
@@ -12,8 +12,14 @@ def group_menu(request):
         # 参加しているグループの情報を取得
         group_member = GroupMember.objects.get(user=request.user)
         group = group_member.group
+        # グループメンバーのリストを取得
+        members = GroupMember.objects.filter(group=group).select_related('user')
         # グループ情報を含むテンプレートをレンダリング
-        return render(request, 'groups/group_menu.html', {'group': group, 'is_member': True})
+        return render(request, 'groups/group_menu.html', {
+            'group': group,
+            'is_member': True,
+            'members': members,
+        })
     else:
         # グループメニューのテンプレートをレンダリング
         return render(request, 'groups/group_menu.html', {'is_member': False})


### PR DESCRIPTION
### 概要
グループメニューにグループメンバーのユーザ名を表示する機能を追加しました。

### 変更内容
- `group_menu`ビューを更新し、グループメンバーを含めるように変更
- グループメンバーをテンプレートに渡す処理を追加
- テンプレートを更新し、グループメンバーのユーザ名のリストを表示するように変更

### テスト方法
1. グループに参加しているユーザーでログインします。
2. グループメニュー画面に移動します。
3. グループメンバーのユーザ名がリストとして表示されていることを確認します。

### 関連するIssue
- #54 