### PR TITLE
fix-data-bugs-timezone

### DIFF
--- a/src/chat/views.py
+++ b/src/chat/views.py
@@ -11,6 +11,7 @@ import openai
 import requests
 from bs4 import BeautifulSoup
 from django.utils import timezone
+from django.utils.timezone import localtime
 from .models import SleepAdvice
 
 @login_required
@@ -62,7 +63,7 @@ def load_advice_from_file(filename='sleep_advice.json'):
 
 # 今日のデータが既に存在するか確認
 def check_today_data(user):
-    today = timezone.now().date()
+    today = localtime(timezone.now()).date()  # 日本時間で今日の日付を取得
     return SleepAdvice.objects.filter(user=user, created_at__date=today).exists()
 
 # ビュー関数

--- a/src/progress/views.py
+++ b/src/progress/views.py
@@ -71,7 +71,7 @@ def generate_plot(start_week, dates, values, ylabel, title, plot_type='scatter',
         text_labels = [float_to_time_str(v) if v is not None else None for v in converted_values]
     elif ylabel == '睡眠時間 (時間)':
         y_axis = dict(tickmode='array', tickvals=list(range(int(max_value) + 1)), ticktext=[f"{h:02d}:00" for h in range(int(max_value) + 1)])
-        text_labels = [f"{v:.2f}時間" if v is not None else None for v in converted_values]  # 睡眠時間を小数点付きで表示
+        text_labels = [float_to_time_str(v) if v is not None else None for v in converted_values]
     else:
         y_axis = dict(range=[0, max_value + 1])
         text_labels = [None] * len(converted_values)


### PR DESCRIPTION
「回答済みです」部分の時間をtimezoneからlocaltimeにしました。
また、就寝起床時刻と睡眠時間をtimezoneからlocaltimeにしました。

debug.logなども見て日付が正しいか確認してください。
編集した理由としては、timezoneは日本時間よりも遅いので早朝などはうまく表示されない可能性があります。例えば、25日の朝にデータを入力したのに24日に表示されるなどです。そのため、可視化する際にtimezoneをlocaltimeに変更しました。

修正後のdebug.log
DEBUG 2024-09-25 09:15:52,477 views Sleep data dictionary: {datetime.date(2024, 9, 25): <SleepAdvice: Masaki2 - 2024-09-24 23:21:38.933671+00:00>}

以前はtimezoneが24日だと以下のようにになっていました。
{datetime.date(2024, 9, 24):