### PR TITLE
Add feature to display group mission and today's user response on the home screen

### DIFF
--- a/src/groups/templates/groups/home.html
+++ b/src/groups/templates/groups/home.html
@@ -137,7 +137,7 @@
                 <p>取り組みたいこと：<strong>{{ answer.topic_question }}</strong></p>
               {% endif %}
             {% else %}
-              <p>回答状況：未回答</p>
+              <p>回答状況：<strong>未回答</strong></p>
             {% endif %}
           </div>
           <div class="card-footer">

--- a/src/groups/templates/groups/home.html
+++ b/src/groups/templates/groups/home.html
@@ -21,17 +21,19 @@
               <h2>グループの情報</h2>
             </div>
             <div class="card-body">
-              <p><strong>ミッション：</strong> </p>
-              <p><strong>グループの種類：</strong>
-                {% if group.is_private %}
-                  プライベート
-                {% else %}
-                  パブリック
-                {% endif %}
+              <p>ミッション：<strong>{{ mission.mission }}</strong> </p>
+              <p>グループの種類：
+                <strong>
+                  {% if group.is_private %}
+                    プライベート
+                  {% else %}
+                    パブリック
+                  {% endif %}
+                </strong>
               </p>
               {% if group.invite_code %}
                 <!-- グループがプライベートで招待コードがある場合の表示 -->
-                <p><strong>招待コード：</strong> {{ group.invite_code }}</p>
+                <p>招待コード：<strong>{{ group.invite_code }}</strong></p>
               {% endif %}
             </div>
             <div class="card-footer">
@@ -122,7 +124,21 @@
             <h2>本日の回答</h2>
           </div>
           <div class="card-body">
-            <p>回答状況：{{ advice }}</p>
+            {% if has_answered_today %}
+              <p>回答状況：<strong>回答済み</strong></p>
+              <p>就寝時刻：<strong>{{ answer.sleep_time }}</strong></p>
+              <p>起床時刻：<strong>{{ answer.wake_time }}</strong></p>
+              <p>睡眠時間：<strong>{{ answer.sleep_duration }}</strong></p>
+              <p>睡眠の質：<strong>{{ answer.sleep_quality }}</strong></p>
+              <p>寝る前にやったこと：<strong>{{ answer.pre_sleep_activities }}</strong></p>
+              {% if is_member %}
+                <p>ミッション達成度：<strong>{{ answer.mission_achievement }}</strong></p>
+              {% else %}
+                <p>取り組みたいこと：<strong>{{ answer.topic_question }}</strong></p>
+              {% endif %}
+            {% else %}
+              <p>回答状況：未回答</p>
+            {% endif %}
           </div>
           <div class="card-footer">
             <div class="d-grid gap-2">
@@ -141,8 +157,10 @@
             <ul class="list-group">
               {% for group in groups %}
                 <li class="list-group-item">
-                  <strong>ミッション：</strong> <br>
-                  <strong>メンバー：</strong>
+                  {% with group_mission=group_missions|get_item:group.id %}
+                    ミッション：<strong>{{ group_mission.mission }}</strong> <br>
+                  {% endwith %}
+                  メンバー：
                   <ul>
                     {% with members=group_members|get_item:group.id %}
                       {% for member in members %}

--- a/src/groups/views.py
+++ b/src/groups/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.db.models import Count
 from django.core.exceptions import ValidationError
 from .models import Group, GroupMember
-from chat.models import Message
+from chat.models import Message, Mission, SleepAdvice
 from chat.views import check_today_data
 
 # HTMLテンプレートをレンダリングするビュー
@@ -17,33 +17,55 @@ def home(request):
             # 参加しているグループの情報を取得
             group_member = GroupMember.objects.get(user=request.user)
             group = group_member.group
+            mission = Mission.objects.filter(group=group).order_by('-created_at').first()
             # 最新のメッセージを取得
             latest_message = Message.objects.filter(group=group).order_by('-timestamp').first()
             # パブリックグループとメンバーの一覧を取得（最大10件）
             groups = Group.objects.filter(is_private=False).exclude(id=group.id)[:10]
             group_members = {g.id: GroupMember.objects.filter(group=g) for g in groups}
-            advice = check_today_data(request.user)
-            # グループ情報と最新のメッセージ、他のグループとメンバーの一覧を含むテンプレートをレンダリング
-            return render(request, 'groups/home.html', {
+            group_missions = {g.id: Mission.objects.filter(group=g).order_by('-created_at').first() for g in groups}
+            has_answered_today = check_today_data(request.user)
+
+            response_data = {
                 'group': group,
+                'mission': mission,
                 'is_member': True,
                 'latest_message': latest_message,
                 'groups': groups,
                 'group_members': group_members,
-                'advice': advice
-            })
+                'group_missions': group_missions,
+                'has_answered_today': has_answered_today
+            }
+
+            # 今日の質問に回答済みの場合、回答を取得
+            if has_answered_today:
+                answer = SleepAdvice.objects.filter(user=request.user).order_by('-created_at').first()
+                response_data['answer'] = answer
+
+            # グループ情報と最新のメッセージ、他のグループとメンバーの一覧を含むテンプレートをレンダリング
+            return render(request, 'groups/home.html', response_data)
         else:
             # パブリックグループとメンバーの一覧を取得（最大10件）
             groups = Group.objects.filter(is_private=False)[:10]
             group_members = {g.id: GroupMember.objects.filter(group=g) for g in groups}
-            advice = check_today_data(request.user)
-            # グループメニューのテンプレートをレンダリング
-            return render(request, 'groups/home.html', {
+            group_missions = {g.id: Mission.objects.filter(group=g).order_by('-created_at').first() for g in groups}
+            has_answered_today = check_today_data(request.user)
+
+            response_data = {
                 'is_member': False,
                 'groups': groups,
                 'group_members': group_members,
-                'advice': advice
-            })
+                'group_missions': group_missions,
+                'has_answered_today': has_answered_today
+            }
+
+            # 今日の質問に回答済みの場合、回答を取得
+            if has_answered_today:
+                answer = SleepAdvice.objects.filter(user=request.user).order_by('-created_at').first()
+                response_data['answer'] = answer
+
+            # グループメニューのテンプレートをレンダリング
+            return render(request, 'groups/home.html', response_data)
     else:
         # ユーザーが認証されていない場合
         return render(request, 'groups/home.html')


### PR DESCRIPTION
### 概要
ホーム画面にグループのミッション内容とその日の回答内容を表示するようにしました。

### 変更内容
- グループ参加しているときにグループ情報にミッション内容を表示するように
- 他のパブリックグループのミッション内容も表示するように
- 回答状況の表示をTrue/Falseではなく回答済み/未回答にして分かりやすく
- 回答状況と合わせて、回答済みの場合は回答内容を表示するように

### テスト方法
1. 質問未回答のアカウントでホーム画面に移動する
2. 回答状況の表示とミッションの表示が正しいことを確認する
3. 質問に回答後、再度回答状況を確認する
4. 回答内容が正しく表示されることを確認する

### 関連するIssue
- #129 